### PR TITLE
fix: Pull in url correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ May or may not get to these todo items, more so if I have time and noticed I sho
 - [x] Copy over media
 - [x] Add option to match on title
 - [ ] Add test coverage
+- [ ] Clean up completed action scheduler history
 
 ## Credits
 

--- a/auto-copy-posts-for-wordpress.php
+++ b/auto-copy-posts-for-wordpress.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:       Auto Copy Posts for WordPress
  * Description:       Sync posts from one WordPress site to another
- * Version:           1.9.1
+ * Version:           1.9.2
  * Requires PHP:      8.0
  * Author:            Nick Stewart
  * Author URI:        https://nickstewart.me

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI: https://nickstewart.me
 Tags: sync, copy, posts
 Requires at least: 5.3
 Tested up to: 6.1.1
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 Requires PHP: 8.0
 
 Sync posts from one Wordpress site to another
@@ -14,6 +14,10 @@ Sync posts from one Wordpress site to another
 A simple WordPress plugin that can sync posts from one WordPress site to another using the REST API.
 
 == Changelog ==
+
+= 1.9.2 =
+
+- Hotfix, site url was not pulling in correctly
 
 = 1.9.1 =
 

--- a/src/AutoCopy.php
+++ b/src/AutoCopy.php
@@ -7,7 +7,7 @@ use Nickstewart\AutoCopy\Events;
 use Carbon\Carbon;
 use Jenssegers\Blade\Blade;
 
-define('AUTO_COPY_POSTS_VERSION', '1.9.1');
+define('AUTO_COPY_POSTS_VERSION', '1.9.2');
 define('AUTO_COPY_POSTS_FILE', __FILE__);
 
 class AutoCopy {
@@ -888,8 +888,8 @@ WHERE meta.`meta_key` = %s
 	): string {
 		$post_id = self::mutatePostId($post['id']);
 
-		if (empty($mutated_id)) {
-			AutoCopy::logError('No site url set');
+		if (empty($post_id)) {
+			AutoCopy::logError('No site url set when fetching transient');
 			return '';
 		}
 
@@ -927,13 +927,9 @@ WHERE meta.`meta_key` = %s
 	 */
 	public static function mutatePostId(int $id): string {
 		//site url with id append
+		$site_url = self::getSiteUrl();
 
-		$base_url = apply_filters(
-			'auto_copy_posts_site_url',
-			self::pluginSetting('auto_copy_posts_site_url'),
-		);
-
-		$url_array = parse_url($base_url);
+		$url_array = parse_url($site_url);
 		$host = $url_array['host'];
 		$host_url_parts = explode('.', $host);
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -112,7 +112,7 @@ class Events {
 		string $post_type = null
 	): void {
 		if (empty($posts)) {
-			AutoCopy::logError('There wo no posts for ' . $post_type);
+			AutoCopy::logError('There were no posts for ' . $post_type);
 			return;
 		}
 
@@ -433,7 +433,7 @@ class Events {
 		);
 
 		if (empty($site_url)) {
-			AutoCopy::logError('No site url set');
+			AutoCopy::logError('No site url set when creating post');
 			return;
 		}
 

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -17,7 +17,7 @@ class Posts {
 		$base_url = AutoCopy::getSiteUrl();
 
 		if (empty($base_url)) {
-			AutoCopy::logError('No site url set');
+			AutoCopy::logError('No site url set when requesting posts');
 			return false;
 		}
 
@@ -90,7 +90,7 @@ class Posts {
 		$base_url = AutoCopy::getSiteUrl();
 
 		if (empty($base_url)) {
-			AutoCopy::logError('No site url set');
+			AutoCopy::logError('No site url set when requesting post');
 			return;
 		}
 
@@ -131,7 +131,9 @@ class Posts {
 		$base_url = AutoCopy::getSiteUrl();
 
 		if (empty($base_url)) {
-			AutoCopy::logError('No site url set');
+			AutoCopy::logError(
+				'No site url set when requesting media attachment',
+			);
 			return false;
 		}
 


### PR DESCRIPTION
I broke the plugin pulling in data with the last feature request

This fixes pulling in the URL and I also made the error log a little bit more descriptive 